### PR TITLE
Add option for merging without reviews

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ async function run(): Promise<void> {
             ready_for_merge_labels: core.getInput('readyForMerge').split(','),
             waiting_for_author_labels: core.getInput('waitingForAuthor').split(','),
             requires_description: to_bool(core.getInput('requireDescription')),
+            allow_merge_without_review: to_bool(core.getInput('allowMergeWithoutReview')),
             ci_passed_labels: core.getInput('ciPassed').split(','),
             required_checks: core.getInput('requiredChecks').split(','),
         };

--- a/src/process.ts
+++ b/src/process.ts
@@ -118,7 +118,6 @@ export async function process_event(
             core.debug(`Detected ${pr.requested_reviewers.length} pending reviewers`);
             todo = Todo.WaitingOnReview;
         } else {
-
             // Check the state of reviewers to determine if we are ready to be
             // merged or not
             const reviews = await octo.pulls.listReviews({

--- a/src/process.ts
+++ b/src/process.ts
@@ -129,7 +129,6 @@ export async function process_event(
 
             const author_id: number = pr.user.id;
 
-
             // If any of the reviews are not APPROVED, we mark the PR as still
             // waiting on review
             if (reviews.data.length > 0) {

--- a/src/process.ts
+++ b/src/process.ts
@@ -175,8 +175,6 @@ export async function process_event(
                     todo = Todo.WaitingOnReview;
                 }
             }
-
-
         }
 
         if (todo == Todo.ReadyForMerge && cfg.requires_description) {


### PR DESCRIPTION
Adds option for allowing a PR to be merged without being reviewed first.
If there are reviewers assigned, they should still be required to approve before merge.